### PR TITLE
feat: スマホ用ブロック操作コントローラーを実装

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>temp-vite-project</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <title>Vive Blocks</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1683,7 +1682,6 @@
       "integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -1694,7 +1692,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1755,7 +1752,6 @@
       "integrity": "sha512-jCzKdm/QK0Kg4V4IK/oMlRZlY+QOcdjv89U2NgKHZk1CYTj82/RVSx1mV/0gqCVMJ/DA+Zf/S4NBWNF8GQ+eqQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.48.0",
         "@typescript-eslint/types": "8.48.0",
@@ -2007,7 +2003,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2151,7 +2146,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -2406,7 +2400,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2881,7 +2874,6 @@
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -2983,7 +2975,6 @@
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
       "dev": true,
       "license": "MPL-2.0",
-      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -3465,7 +3456,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3493,7 +3483,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3535,7 +3524,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3545,7 +3533,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -3776,7 +3763,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3863,7 +3849,6 @@
       "integrity": "sha512-NL8jTlbo0Tn4dUEXEsUg8KeyG/Lkmc4Fnzb8JXN/Ykm9G4HNImjtABMJgkQoVjOBN/j2WAwDTRytdqJbZsah7w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -3985,7 +3970,6 @@
       "integrity": "sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { Board } from './components/Board';
+import { MobileController } from './components/MobileController';
 import { useGameStore } from './store/gameStore';
 import { useGameLoop } from './hooks/useGameLoop';
 
@@ -53,15 +54,16 @@ function App() {
   }, [start]);
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center p-4">
-      <h1 className="text-4xl font-bold mb-8 text-center">
+    <div className="min-h-screen bg-gray-950 text-white flex flex-col items-center justify-center p-2 sm:p-4">
+      <h1 className="text-2xl sm:text-4xl font-bold mb-4 sm:mb-8 text-center">
         Vive Blocks
       </h1>
       {isGameOver && (
         <div className="mb-4 text-red-500 text-xl font-bold">GAME OVER</div>
       )}
       <Board />
-      <div className="mt-4 text-sm text-gray-400 text-center">
+      <MobileController />
+      <div className="mt-4 text-sm text-gray-400 text-center hidden sm:block">
         <p>← →: 移動 | ↑: 回転 | ↓ または Space: 落下</p>
       </div>
     </div>

--- a/src/components/Cell.tsx
+++ b/src/components/Cell.tsx
@@ -13,7 +13,7 @@ export function Cell({ type }: CellProps) {
 
   return (
     <div
-      className={`${colorClass} border border-gray-700 w-8 h-8 min-w-[32px] min-h-[32px]`}
+      className={`${colorClass} border border-gray-700 w-6 h-6 sm:w-8 sm:h-8`}
     />
   );
 }

--- a/src/components/MobileController.tsx
+++ b/src/components/MobileController.tsx
@@ -1,0 +1,146 @@
+import { useCallback, useRef } from 'react';
+import { useGameStore } from '../store/gameStore';
+
+/**
+ * スマホ用ゲームコントローラー
+ * タッチ操作でブロックを操作するためのボタンUI
+ */
+export function MobileController() {
+  const moveLeft = useGameStore((state) => state.moveLeft);
+  const moveRight = useGameStore((state) => state.moveRight);
+  const rotate = useGameStore((state) => state.rotate);
+  const drop = useGameStore((state) => state.drop);
+  const isGameOver = useGameStore((state) => state.isGameOver);
+
+  const intervalRef = useRef<number | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+
+  // 長押しリピート処理を開始
+  const startRepeat = useCallback((action: () => void) => {
+    if (isGameOver) return;
+    action();
+    // 最初の長押し判定まで少し待つ
+    timeoutRef.current = window.setTimeout(() => {
+      intervalRef.current = window.setInterval(() => {
+        action();
+      }, 80);
+    }, 200);
+  }, [isGameOver]);
+
+  // 長押しリピート処理を停止
+  const stopRepeat = useCallback(() => {
+    if (timeoutRef.current !== null) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    if (intervalRef.current !== null) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  // 単発アクション（回転など）
+  const handleAction = useCallback((action: () => void) => {
+    if (isGameOver) return;
+    action();
+  }, [isGameOver]);
+
+  // ボタン共通のタッチイベントハンドラ（長押しリピート対応）
+  const repeatHandlers = useCallback((action: () => void) => ({
+    onTouchStart: (e: React.TouchEvent) => {
+      e.preventDefault();
+      startRepeat(action);
+    },
+    onTouchEnd: (e: React.TouchEvent) => {
+      e.preventDefault();
+      stopRepeat();
+    },
+    onTouchCancel: () => {
+      stopRepeat();
+    },
+    // マウス操作もサポート（デバッグ用）
+    onMouseDown: (e: React.MouseEvent) => {
+      e.preventDefault();
+      startRepeat(action);
+    },
+    onMouseUp: () => {
+      stopRepeat();
+    },
+    onMouseLeave: () => {
+      stopRepeat();
+    },
+  }), [startRepeat, stopRepeat]);
+
+  // 単発タッチイベントハンドラ
+  const singleHandlers = useCallback((action: () => void) => ({
+    onTouchStart: (e: React.TouchEvent) => {
+      e.preventDefault();
+      handleAction(action);
+    },
+    onTouchEnd: (e: React.TouchEvent) => {
+      e.preventDefault();
+    },
+    onMouseDown: (e: React.MouseEvent) => {
+      e.preventDefault();
+      handleAction(action);
+    },
+  }), [handleAction]);
+
+  const buttonBase =
+    'select-none touch-none rounded-xl font-bold text-white active:scale-95 active:brightness-110 transition-transform duration-75 flex items-center justify-center';
+
+  return (
+    <div className="w-full max-w-xs mx-auto mt-4 select-none touch-none">
+      {/* 上段: 回転ボタン */}
+      <div className="flex justify-center mb-3">
+        <button
+          type="button"
+          className={`${buttonBase} w-16 h-16 bg-purple-600 text-2xl`}
+          {...singleHandlers(rotate)}
+        >
+          <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21.5 2v6h-6" />
+            <path d="M21.34 13.72A9 9 0 1 1 18.57 5.06L21.5 8" />
+          </svg>
+        </button>
+      </div>
+
+      {/* 下段: 左・落下・右 */}
+      <div className="flex justify-center items-center gap-3">
+        {/* 左移動 */}
+        <button
+          type="button"
+          className={`${buttonBase} w-20 h-20 bg-blue-600 text-3xl`}
+          {...repeatHandlers(moveLeft)}
+        >
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M15 18l-6-6 6-6" />
+          </svg>
+        </button>
+
+        {/* 落下 */}
+        <button
+          type="button"
+          className={`${buttonBase} w-20 h-20 bg-orange-600 text-3xl`}
+          {...repeatHandlers(drop)}
+        >
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M12 5v14" />
+            <path d="M19 12l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {/* 右移動 */}
+        <button
+          type="button"
+          className={`${buttonBase} w-20 h-20 bg-blue-600 text-3xl`}
+          {...repeatHandlers(moveRight)}
+        >
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M9 18l6-6-6-6" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
- MobileControllerコンポーネントを新規作成（タッチ対応ボタンUI）
  - 回転ボタン（上段中央・紫）
  - 左移動・落下・右移動ボタン（下段・長押しリピート対応）
  - タッチイベントとマウスイベントの両方をサポート
- セルサイズをレスポンシブ対応（モバイル: 24px、デスクトップ: 32px）
- タイトル・パディングをモバイル画面向けに調整
- viewportメタタグを最適化（ピンチズーム防止）
- キーボード操作説明をデスクトップのみ表示に変更

https://claude.ai/code/session_01DbbgmoieESu2tuKH4PVfvh